### PR TITLE
Updated regex for newer versions of puppet

### DIFF
--- a/puppet-ls
+++ b/puppet-ls
@@ -68,7 +68,7 @@ trap "rm -f $catalog_filelist $lister_filelist" 0 1 2 15
 # get files puppet knows about - you might not need both of these.
 (
   grep -h "title: /" /var/lib/puppet/client_yaml/catalog/*.yaml | awk '{ print $NF }' ;
-  sed -e '/"File\[/!d' -e 's/"File\[//' -e 's/\]"://' -e 's/ //g' < /var/lib/puppet/state/state.yaml
+  sed -e '/File\[/!d' -e 's/File\[//' -e 's/\]://' -e 's/ //g' < /var/lib/puppet/state/state.yaml
 ) | sort > $catalog_filelist
 
 $lister | sort > $lister_filelist


### PR DESCRIPTION
The regex for parsing state.yaml is incorrect for more recent versions of puppet.

All credit to @djmitche(https://github.com/djmitche)

Perhaps adding in a check based on the version of puppet installed would make sense here to switch between the 2 different regular expressions.
