### PR TITLE
Make ls handle rootdir dotfiles (backslash the !)

### DIFF
--- a/puppet-ls
+++ b/puppet-ls
@@ -62,7 +62,7 @@ if [ -n "$follow_links" ];then
 elif [ -n "$recursive" ];then
   lister="find $target"
 else
-  lister="ls -d1 $target/*"
+  lister="ls -d1 $target/.[\\!.]* $target/*"
 fi
 
 catalog_filelist=$(mktemp -q /tmp/$appname.XXXXXX)

--- a/puppet-ls
+++ b/puppet-ls
@@ -58,11 +58,11 @@ target="${1-$(pwd)}"
 target="${target%/}"
 
 if [ -n "$follow_links" ];then
-  lister="find -L $target"
+  lister="find -L \"\$target\""
 elif [ -n "$recursive" ];then
-  lister="find $target"
+  lister="find \"\$target\""
 else
-  lister="ls -d1 $target/"'.[!.]*'" $target/*"
+  lister="find \"\$target\" -mindepth 1 -maxdepth 1"
 fi
 
 catalog_filelist=$(mktemp -q /tmp/$appname.XXXXXX)
@@ -77,6 +77,6 @@ trap "rm -f $catalog_filelist $lister_filelist" 0 1 2 15
   sed -e '/"File\[/!d' -e 's/"File\[//' -e 's/\]"://' -e 's/ //g' < /var/lib/puppet/state/state.yaml
 ) | sort > $catalog_filelist
 
-$lister | sort > $lister_filelist
+eval "$lister" | sort > $lister_filelist
 
 $comm $catalog_filelist $lister_filelist

--- a/puppet-ls
+++ b/puppet-ls
@@ -62,7 +62,7 @@ if [ -n "$follow_links" ];then
 elif [ -n "$recursive" ];then
   lister="find $target"
 else
-  lister="ls -d1 $target/.[\\!.]* $target/*"
+  lister="ls -d1 $target/"'.[!.]*'" $target/*"
 fi
 
 catalog_filelist=$(mktemp -q /tmp/$appname.XXXXXX)


### PR DESCRIPTION
This ensures the `ls` invocation doesn't miss any dotfiles in the `$target` directory, while avoiding `.` and `..`. It backslashes the `!` in case any shells are setup to do unexpected voodoo with that symbol...